### PR TITLE
[actions] changes in pipeline after changes in terraform behavior

### DIFF
--- a/.github/workflows/tf_build_deploy.yaml
+++ b/.github/workflows/tf_build_deploy.yaml
@@ -147,9 +147,9 @@ jobs:
       uses: actions/download-artifact@v4
       with:
         name: tfplan
-    - name: Reinstate executables permissions
-      run: |        
-        chmod u+x -R .terraform
+    #- name: Reinstate executables permissions
+    #  run: |        
+    #    chmod u+x -R .terraform
     # Terraform Apply
     - name: Terraform Apply
       run: |                

--- a/.github/workflows/tf_build_deploy.yaml
+++ b/.github/workflows/tf_build_deploy.yaml
@@ -12,6 +12,7 @@ on:
     - main
     paths:
     - Terraform/**
+    - .github/**
   workflow_dispatch:  
 
 #Special permissions required for OIDC authentication


### PR DESCRIPTION
- *.terraform* folder no longer seems to be created during plan phase. I removed the step in TF apply job which reinstated exec permissions for files in this folder.
- added trigger to build and deploy action so the change in action definition triggers build action on MR