### PR TITLE
[actions] added missing trigger on push to main

### DIFF
--- a/.github/workflows/tf_build_deploy.yaml
+++ b/.github/workflows/tf_build_deploy.yaml
@@ -7,6 +7,7 @@ on:
     - main
     paths:
     - Terraform/**
+    - .github/**
   pull_request:
     branches:
     - main


### PR DESCRIPTION
Added trigger so TF build and deploy action is triggered when there is a push to main and Github actions definitions change. 