### PR TITLE
[actions] fixed missing .terraform folder in plan output

### DIFF
--- a/.github/workflows/tf_build_deploy.yaml
+++ b/.github/workflows/tf_build_deploy.yaml
@@ -77,16 +77,13 @@ jobs:
           exit 0
         fi
 
-    - name: Debug step
-      run: |
-        ls -laR
-
     # Save plan to artifacts  
     - name: Publish Terraform Plan
       uses: actions/upload-artifact@v4
       with:
         name: tfplan
         path: Terraform
+        include-hidden-files: true
         
     # Create string output of Terraform Plan
     - name: Create String Output
@@ -153,9 +150,9 @@ jobs:
       uses: actions/download-artifact@v4
       with:
         name: tfplan
-    #- name: Reinstate executables permissions
-    #  run: |        
-    #    chmod u+x -R .terraform
+    - name: Reinstate executables permissions
+      run: |        
+        chmod u+x -R .terraform
     # Terraform Apply
     - name: Terraform Apply
       run: |                

--- a/.github/workflows/tf_build_deploy.yaml
+++ b/.github/workflows/tf_build_deploy.yaml
@@ -76,7 +76,11 @@ jobs:
         else 
           exit 0
         fi
-        
+
+    - name: Debug step
+      run: |
+        ls -lR
+                
     # Save plan to artifacts  
     - name: Publish Terraform Plan
       uses: actions/upload-artifact@v4

--- a/.github/workflows/tf_build_deploy.yaml
+++ b/.github/workflows/tf_build_deploy.yaml
@@ -79,8 +79,8 @@ jobs:
 
     - name: Debug step
       run: |
-        ls -lR
-                
+        ls -laR
+
     # Save plan to artifacts  
     - name: Publish Terraform Plan
       uses: actions/upload-artifact@v4


### PR DESCRIPTION
- fixed: changed upload artifacts step in TF plan job so it correctly uploads _.terraform_ folder. There was a behavior change in `upload-artifact@v4` action v 4.4