### PR TITLE
[AF] move configuration file for AF to storage account

### DIFF
--- a/Terraform/Azure Functions/main.tf
+++ b/Terraform/Azure Functions/main.tf
@@ -88,6 +88,7 @@ resource "azurerm_windows_function_app" "fapp" {
     WEBSITE_CONTENTSHARE                     = "${var.fapp_name}-${random_string.sharesuffix.result}"
     KV_NAME                                  = "${var.kv_name}"
     TENANT_ID                                = data.azurerm_client_config.current.tenant_id
+    CONFIG_STORAGE                           = azurerm_storage_account.fapp-data.name
     netFrameworkVersion                      = "v6.0"
   }
 

--- a/Terraform/Azure Functions/main.tf
+++ b/Terraform/Azure Functions/main.tf
@@ -119,3 +119,9 @@ resource "azurerm_role_assignment" "func_access_to_kv" {
   role_definition_name = "Key Vault Secrets User"
   principal_id         = azurerm_windows_function_app.fapp.identity[0].principal_id
 }
+
+resource "azurerm_role_assignment" "func_access_to_sa_data_blobs" {
+  scope                = azurerm_storage_account.fapp-data.id
+  role_definition_name = "Storage Blob Data Contributor"
+  principal_id         = azurerm_windows_function_app.fapp.identity[0].principal_id
+}

--- a/src/azurefunction/azurefunction.csproj
+++ b/src/azurefunction/azurefunction.csproj
@@ -10,6 +10,9 @@
     <Content Include="host.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
+    <Content Include="local.settings.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
     <None Update="local.settings.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       <CopyToPublishDirectory>Never</CopyToPublishDirectory>

--- a/src/azurefunction/azurefunction.csproj
+++ b/src/azurefunction/azurefunction.csproj
@@ -10,9 +10,6 @@
     <Content Include="host.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
-    <Content Include="local.settings.json">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </Content>
     <None Update="local.settings.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       <CopyToPublishDirectory>Never</CopyToPublishDirectory>

--- a/src/common_code/Configuration.cs
+++ b/src/common_code/Configuration.cs
@@ -172,7 +172,8 @@ namespace Ecowitt
             {
                 try
                 {
-                    var blobServiceClient = new BlobServiceClient(new Uri("https://" + _configStorage + ".blob.core.windows.net"), new DefaultAzureCredential());
+                    var blobServiceClient = new BlobServiceClient(new Uri("https://" + _configStorage + ".blob.core.windows.net"), 
+                        new DefaultAzureCredential(AzureCredential));
                     var containerClient = blobServiceClient.GetBlobContainerClient("config");
                     var blobClient = containerClient.GetBlobClient(ConfigFileName);
                     var response = blobClient.Download();


### PR DESCRIPTION
- changed; configuration file for Azure Function version is now kept in the storage account 
- added: new configuration parameter for storage account CONFIG_STORAGE